### PR TITLE
Translate to Chinese

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -6,7 +6,9 @@ var REPLACEMENTS = {
     'terrorista': 'covarde',
     'Terrorista': 'Covarde',
     'terrorismo': 'covardia',
-    'Terrorismo': 'Covardia'
+    'Terrorismo': 'Covardia',
+    // CN Translation
+    '恐怖': '懦弱'
 };
 
 var replaceTerror = function(textNode) {

--- a/contentscript.js
+++ b/contentscript.js
@@ -2,7 +2,7 @@ var REPLACEMENTS = {
     'terrorist': 'coward',
     'Terrorist': 'Coward',
     'terrorism': 'cowardice',
-    'Terrorism': 'Cowardice'
+    'Terrorism': 'Cowardice',
     'terrorista': 'covarde',
     'Terrorista': 'Covarde',
     'terrorismo': 'covardia',


### PR DESCRIPTION
By changing terrorist 恐怖 to coward 懦弱， it also changes terrorism 恐怖主义 to cowardice 懦弱主意 as well. In traditional Chinese and simplified Chinese those two words written in the same way so one line change can cover all of them. 
